### PR TITLE
Fix game exports failing

### DIFF
--- a/addons/RichLogger/LoggerToolbarPlugin.cs
+++ b/addons/RichLogger/LoggerToolbarPlugin.cs
@@ -1,3 +1,4 @@
+#if TOOLS
 using Godot;
 
 [Tool]
@@ -47,3 +48,4 @@ public partial class LoggerToolbarPlugin : EditorPlugin
         _toolbar = null;
     }
 }
+#endif


### PR DESCRIPTION
LoggerToolbarPlugin.cs was missing a preprocessor that's required for plugins made in C# ([source](https://docs.godotengine.org/en/stable/tutorials/plugins/editor/making_plugins.html)), otherwise it will fail when exporting the game with a .NET compile error.