### PR TITLE
Adjusted toolbar ui + nullable fixes

### DIFF
--- a/addons/RichLogger/Logger.cs
+++ b/addons/RichLogger/Logger.cs
@@ -119,7 +119,7 @@ public static class Logger
     {
         if (CurrentLevel < level) return;
 
-        var objString = GodotObject.IsInstanceValid(obj as GodotObject) ? (obj as GodotObject).ToString() : obj?.ToString() ?? "null";
+        var objString = obj is GodotObject gdObj && GodotObject.IsInstanceValid(gdObj) ? gdObj.ToString() : obj?.ToString() ?? "null";
 
         Log(level, $"{context}: {objString}");
     }

--- a/addons/RichLogger/LoggerToolbar.cs
+++ b/addons/RichLogger/LoggerToolbar.cs
@@ -3,10 +3,10 @@ using Godot;
 [Tool]
 public partial class LoggerToolbar : HBoxContainer
 {
-    private OptionButton _logLevelDropdown;
-    private CheckBox     _stackTraceToggle;
-    private SpinBox      _stackDepthSpinner;
-    private Button       _testLogButton;
+    private OptionButton _logLevelDropdown = null!;
+    private CheckBox _stackTraceToggle = null!;
+    private SpinBox _stackDepthSpinner = null!;
+    private Button _testLogButton = null!;
 
     private string _pluginSettingsPath = "user://logger_settings.cfg";
 
@@ -27,10 +27,10 @@ public partial class LoggerToolbar : HBoxContainer
         AddChild(label);
 
         _logLevelDropdown = new OptionButton();
-        _logLevelDropdown.AddItem("Error",   (int)LogLevel.Error);
+        _logLevelDropdown.AddItem("Error", (int)LogLevel.Error);
         _logLevelDropdown.AddItem("Warning", (int)LogLevel.Warning);
-        _logLevelDropdown.AddItem("Info",    (int)LogLevel.Info);
-        _logLevelDropdown.AddItem("Debug",   (int)LogLevel.Debug);
+        _logLevelDropdown.AddItem("Info", (int)LogLevel.Info);
+        _logLevelDropdown.AddItem("Debug", (int)LogLevel.Debug);
         _logLevelDropdown.AddItem("Verbose", (int)LogLevel.Verbose);
         _logLevelDropdown.CustomMinimumSize = new Vector2(100, 0);
         _logLevelDropdown.TooltipText = "Set the global logging level";

--- a/addons/RichLogger/LoggerToolbarPlugin.cs
+++ b/addons/RichLogger/LoggerToolbarPlugin.cs
@@ -1,7 +1,7 @@
 #if TOOLS
+using System;
 using System.Linq;
 using Godot;
-
 [Tool]
 public partial class LoggerToolbarPlugin : EditorPlugin
 {
@@ -14,32 +14,59 @@ public partial class LoggerToolbarPlugin : EditorPlugin
 		var tempControl = new Control { Name = "Temp" };
 		var tabButton = AddControlToBottomPanel(tempControl, "Temp");
 
-#if GODOT4_4_OR_GREATER
-		var hBoxParent = tabButton.GetParent().GetParent().GetParent();
-#elif GODOT4_3_OR_GREATER
-		var hBoxParent = tabButton.GetParent().GetParent();
-#else
-		GD.PrintErr($"[{nameof(LoggerToolbarPlugin)}] Unsupported Godot version!");
-		var hBoxParent = tabButton.GetParent().GetParent().GetParent();
-#endif
-		RemoveControlFromBottomPanel(tempControl);
-		tempControl.QueueFree();
-
-		var editorToaster = hBoxParent.GetChildren().FirstOrDefault(x => x.Name.ToString().Contains("EditorToaster"));
-		if (editorToaster == null)
+		// Get the BottomPanel parent container of all buttons
+		foreach (var item in tempControl.GetParent().GetChildren())
 		{
-			GD.PrintErr($"[{nameof(LoggerToolbarPlugin)}] Failed to find EditorToaster!");
-			return;
+			// Find the button for the 'output' tab / panel
+			if (item.Name.ToString().Contains("EditorLog"))
+			{
+				// Find the left VBoxContainer (vb_left in the C++ code)
+				var vbLeft = FindOutputPanelVBoxLeft(item);
+				if (vbLeft != null)
+				{
+					vbLeft.AddChild(_toolbar);
+				}
+				else
+				{
+					GD.PrintErr("[CSharpRichLogger] Could not find vb_left container in EditorLog!");
+				}
+			}
 		}
-
-		if (editorToaster.GetChild(0) is not VBoxContainer outputVBoxContainer)
-		{
-			GD.PrintErr($"[{nameof(LoggerToolbarPlugin)}] Failed to find output VBoxContainer!");
-			return;
-		}
-
-		outputVBoxContainer.AddChild(_toolbar);
 		_toolbar.SizeFlagsHorizontal = Control.SizeFlags.ExpandFill;
+		RemoveControlFromBottomPanel(tempControl);
+	}
+
+	/// <summary>
+	/// Finds the left VBoxContainer in the EditorLog node.
+	/// See: https://github.com/godotengine/godot/blob/master/editor/editor_log.cpp for how the output panel
+	/// is built interally in godot
+	/// </summary>
+	/// <param name="editorLog"></param>
+	/// <returns></returns>
+	private VBoxContainer? FindOutputPanelVBoxLeft(Node editorLog)
+	{
+		// The structure is: EditorLog (HBoxContainer) -> VBoxContainer (vb_left)
+		foreach (Node child in editorLog.GetChildren())
+		{
+			if (child is VBoxContainer vbox)
+			{
+				// Check if this VBoxContainer has the log and search box
+				bool hasRichTextLabel = false;
+				bool hasLineEdit = false;
+				
+				foreach (Node grandchild in vbox.GetChildren())
+				{
+					if (grandchild is RichTextLabel) hasRichTextLabel = true;
+					if (grandchild is LineEdit lineEdit && lineEdit.PlaceholderText.Contains("Filter")) hasLineEdit = true;
+				}
+				
+				if (hasRichTextLabel && hasLineEdit)
+				{
+					return vbox;
+				}
+			}
+		}
+		return null;
 	}
 
 	public override void _ExitTree()


### PR DESCRIPTION
Fixes #4 - also simplifies the ui to no longer need #if conditionals depending on the version of godot 4. Tested in godot 4.3, 4.4.1, and 4.5 mono versions

Godot 4.3:

<img width="1280" height="747" alt="log_options_panel_closed_4_3" src="https://github.com/user-attachments/assets/b6cb0360-a0d7-483c-a121-afcc64ec8994" />
<img width="1280" height="747" alt="log_options_panel_open_4_3" src="https://github.com/user-attachments/assets/141f26d2-7a63-48a4-af2c-a099566e628e" />

Godot 4.4.1:

<img width="1280" height="747" alt="log_options_panel_open_4_4" src="https://github.com/user-attachments/assets/052a16b0-4956-4668-9e49-dd8e0f76eb15" />
<img width="1280" height="747" alt="log_options_panel_closed_4_4" src="https://github.com/user-attachments/assets/642e7c51-4262-43c9-8ba5-36116ca2bd4c" />

Godot 4.5:

<img width="1280" height="747" alt="log_options_panel_open_4_5" src="https://github.com/user-attachments/assets/c0febf40-cb7f-485e-9281-f62fb78e1ef9" />
<img width="1280" height="747" alt="log_options_panel_closed_4_5" src="https://github.com/user-attachments/assets/20a582ec-1498-4289-8e34-a8b96f8ea567" />

Also fixes some issues with nullable warnings in the plugin when `<Nullable>enable</Nullable>` is set in the project settings
