### PR TITLE
feat: align with new Godot Asset Store

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,23 +1,8 @@
 # Normalize EOL for all files that Git considers text files.
 * text=auto eol=lf
 
-# Exclude from GitHub archive downloads (used by Godot Asset Library)
-.editorconfig    export-ignore
-.gitattributes   export-ignore
-.gitignore       export-ignore
-.github/         export-ignore
-.idea/           export-ignore
-icon.svg         export-ignore
-icon.svg.import  export-ignore
-icon.png         export-ignore
-icon.png.import  export-ignore
-screen.png       export-ignore
-screen.png.import export-ignore
-scene.tscn       export-ignore
-Scene.cs         export-ignore
-Scene.cs.uid     export-ignore
-RichLogger.csproj export-ignore
-RichLogger.sln   export-ignore
-README.md        export-ignore
-LICENSE          export-ignore
-project.godot    export-ignore
+# Exclude everything except the addon from GitHub archive downloads
+# (used by Godot Asset Library). Negative patterns (!) are forbidden in
+# .gitattributes, but unsetting the attribute on a later line works:
+/* export-ignore
+/addons -export-ignore

--- a/.github/actions/telegram-notify/action.yml
+++ b/.github/actions/telegram-notify/action.yml
@@ -1,0 +1,31 @@
+name: Telegram Notify
+description: Send a Telegram message via the Bot API. Fails if the secrets are not configured.
+
+inputs:
+  bot-token:
+    description: Telegram bot token (pass secrets.TELEGRAM_BOT_TOKEN)
+    required: true
+  chat-id:
+    description: Telegram chat ID (pass secrets.TELEGRAM_CHAT_ID)
+    required: true
+  message:
+    description: Message text to send
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Send Telegram message
+      shell: bash
+      env:
+        TELEGRAM_BOT_TOKEN: ${{ inputs.bot-token }}
+        TELEGRAM_CHAT_ID: ${{ inputs.chat-id }}
+        TEXT: ${{ inputs.message }}
+      run: |
+        set -euo pipefail
+        [ -n "$TELEGRAM_BOT_TOKEN" ] || { echo "ERROR: TELEGRAM_BOT_TOKEN secret is not set"; exit 1; }
+        [ -n "$TELEGRAM_CHAT_ID" ] || { echo "ERROR: TELEGRAM_CHAT_ID secret is not set"; exit 1; }
+        curl -s --fail -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+          --data-urlencode chat_id="${TELEGRAM_CHAT_ID}" \
+          --data-urlencode text="${TEXT}" > /dev/null
+        echo "Telegram notification sent."

--- a/.github/workflows/check-asset-library.yml
+++ b/.github/workflows/check-asset-library.yml
@@ -5,27 +5,45 @@ on:
     branches: [main]
   schedule:
     - cron: '0 5 * * *'  # Daily 05:00 UTC
+  workflow_dispatch:
 
 jobs:
   check:
-    name: Verify Asset Library points to latest main commit
+    name: Verify Asset Library has latest version
     runs-on: [self-hosted, linux, godot]
     steps:
       - uses: actions/checkout@v6
 
-      - name: Check Asset Library matches HEAD
+      - name: Compare Asset Library version with plugin.cfg
         run: |
+          set -euo pipefail
+          PLUGIN_VERSION=$(grep -oP '^version="\K[0-9]+\.[0-9]+\.[0-9]+(?=")' addons/RichLogger/plugin.cfg)
           RESPONSE=$(curl -s --fail "https://godotengine.org/asset-library/api/asset/4023")
-          ASSET_COMMIT=$(echo "$RESPONSE" | jq -r '.download_commit')
-          HEAD_COMMIT=$(git rev-parse HEAD)
+          ASSET_VERSION=$(echo "$RESPONSE" | jq -r '.version_string')
 
-          echo "Asset Library commit : $ASSET_COMMIT"
-          echo "HEAD commit          : $HEAD_COMMIT"
+          echo "Asset Library version : $ASSET_VERSION"
+          echo "plugin.cfg version    : $PLUGIN_VERSION"
 
-          if [ "$ASSET_COMMIT" != "$HEAD_COMMIT" ]; then
+          if [ "$ASSET_VERSION" != "$PLUGIN_VERSION" ]; then
             echo "ERROR: Asset Library is out of date!"
             echo "Please update: https://godotengine.org/asset-library/asset/4023"
             exit 1
           fi
 
           echo "OK: Asset Library is up to date."
+
+  notify:
+    name: Telegram notification on failure
+    runs-on: [self-hosted, linux, godot]
+    needs: [check]
+    if: failure()
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/telegram-notify
+        with:
+          bot-token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          chat-id: ${{ secrets.TELEGRAM_CHAT_ID }}
+          message: |
+            ❌ RichLogger: Asset Library is out of date!
+            Please update: https://godotengine.org/asset-library/asset/4023
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/check-asset-store.yml
+++ b/.github/workflows/check-asset-store.yml
@@ -1,0 +1,77 @@
+name: Check Asset Store
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 5 * * *'  # Daily 05:00 UTC
+  workflow_dispatch:
+
+jobs:
+  check-store:
+    name: Verify Asset Store has latest version
+    runs-on: [self-hosted, linux, godot]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Compare store version with plugin.cfg
+        run: |
+          set -euo pipefail
+          PLUGIN_VERSION=$(grep -oP '^version="\K[0-9]+\.[0-9]+\.[0-9]+(?=")' addons/RichLogger/plugin.cfg)
+
+          # Store returns an empty response to UA-less requests
+          HTML=$(curl -s --fail -L -A "Mozilla/5.0 (RichLogger CI)" \
+            "https://store.godotengine.org/asset/gorylpe/godot-richlogger-c/")
+
+          # Latest version renders first as data-version="Godot RichLogger C# 1.0.2";
+          # 3-part semver regex skips engine versions (4.3/4.7) in the compat list
+          STORE_VERSION=$(echo "$HTML" \
+            | grep -oP 'data-version="[^"]*?\K[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+
+          if [ -z "$STORE_VERSION" ]; then
+            echo "ERROR: could not extract version from store page (layout changed?)"
+            exit 1
+          fi
+
+          echo "Asset Store version : $STORE_VERSION"
+          echo "plugin.cfg version  : $PLUGIN_VERSION"
+
+          if [ "$STORE_VERSION" != "$PLUGIN_VERSION" ]; then
+            echo "ERROR: Asset Store is out of date!"
+            echo "Run the Release workflow, then upload the zip at:"
+            echo "https://store.godotengine.org/asset/gorylpe/godot-richlogger-c/"
+            exit 1
+          fi
+
+          echo "OK: Asset Store is up to date."
+
+  check-file-sync:
+    name: Verify addon LICENSE/README match root
+    runs-on: [self-hosted, linux, godot]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Diff addon copies against root files
+        run: |
+          git diff --no-index --exit-code LICENSE addons/RichLogger/LICENSE \
+            || { echo "ERROR: addons/RichLogger/LICENSE differs from LICENSE. Run: cp LICENSE addons/RichLogger/LICENSE"; exit 1; }
+          git diff --no-index --exit-code README.md addons/RichLogger/README.md \
+            || { echo "ERROR: addons/RichLogger/README.md differs from README.md. Run: cp README.md addons/RichLogger/README.md"; exit 1; }
+          echo "OK: addon LICENSE and README are in sync."
+
+  notify:
+    name: Telegram notification on failure
+    runs-on: [self-hosted, linux, godot]
+    needs: [check-store, check-file-sync]
+    if: failure()
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/telegram-notify
+        with:
+          bot-token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          chat-id: ${{ secrets.TELEGRAM_CHAT_ID }}
+          message: |
+            ❌ RichLogger: Check Asset Store failed
+            check-store: ${{ needs.check-store.result }}
+            check-file-sync: ${{ needs.check-file-sync.result }}
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create release with addon zip
+    runs-on: [self-hosted, linux, godot]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Read version from plugin.cfg
+        id: version
+        run: |
+          set -euo pipefail
+          VERSION=$(grep -oP '^version="\K[0-9]+\.[0-9]+\.[0-9]+(?=")' addons/RichLogger/plugin.cfg)
+          [ -n "$VERSION" ] || { echo "ERROR: could not parse version from plugin.cfg"; exit 1; }
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Releasing version $VERSION"
+
+      - name: Guard against existing tag
+        run: |
+          set -euo pipefail
+          TAG="v${{ steps.version.outputs.version }}"
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null; then
+            echo "ERROR: tag $TAG already exists. Bump version in plugin.cfg first."
+            exit 1
+          fi
+
+      - name: Verify addon LICENSE/README match root
+        run: |
+          git diff --no-index --exit-code LICENSE addons/RichLogger/LICENSE
+          git diff --no-index --exit-code README.md addons/RichLogger/README.md
+
+      - name: Build addon zip
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          git archive --format=zip -o "richlogger${VERSION}.zip" HEAD addons/RichLogger
+          unzip -l "richlogger${VERSION}.zip"
+
+      - name: Create tag and release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          gh release create "v${VERSION}" "richlogger${VERSION}.zip" \
+            --target "$GITHUB_SHA" \
+            --title "RichLogger ${VERSION}" \
+            --generate-notes
+          echo "Release v${VERSION} created. Upload the zip to the Asset Store:"
+          echo "https://store.godotengine.org/asset/gorylpe/godot-richlogger-c/"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,3 +130,20 @@ jobs:
             echo "FAIL: editor plugin broken on Godot ${GODOT_VERSION}"
             exit 1
           fi
+
+  notify:
+    name: Telegram notification on failure
+    runs-on: [self-hosted, linux, godot]
+    needs: [prepare, test]
+    if: failure()
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/telegram-notify
+        with:
+          bot-token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          chat-id: ${{ secrets.TELEGRAM_CHAT_ID }}
+          message: |
+            ❌ RichLogger: Tests failed (${{ github.event_name }} on ${{ github.ref_name }})
+            prepare: ${{ needs.prepare.result }}
+            test: ${{ needs.test.result }}
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 
 # IDE
 .idea/
+
+# Locally built release zips (CI builds these for releases)
+richlogger*.zip

--- a/RichLogger.csproj
+++ b/RichLogger.csproj
@@ -4,4 +4,7 @@
     <TargetFramework Condition=" '$(GodotTargetPlatform)' == 'android' ">net9.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>
   </PropertyGroup>
+  <ItemGroup>
+    <Content Include="addons\RichLogger\LICENSE" />
+  </ItemGroup>
 </Project>

--- a/addons/RichLogger/LICENSE
+++ b/addons/RichLogger/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Piotr Przestrzelski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/addons/RichLogger/README.md
+++ b/addons/RichLogger/README.md
@@ -1,0 +1,78 @@
+# Godot RichLogger C#
+A feature-rich logging utility addon for Godot 4.x C# projects that enhances the default Godot output panel with additional functionality.
+
+![Screenshot of Godot RichLogger in action](screen.png)
+
+## Features
+- **Enhanced Output Formatting** - Format your logs with rich text, colors, and styling
+- **5 Log Levels** - Error, Warning, Info, Debug, Verbose with visual differentiation
+- **Stack Traces** - Toggle stack traces on/off with configurable depth
+- **Caller Information** - Hover over log level to see class, method, file, and line number
+- **Integrated Toolbar** - Convenient controls added to the output panel
+- **Runtime Settings** - Change log settings during gameplay, updates automatically
+- **File Logging** - Write logs to files, quick access button to open logs directory, non-blocking file I/O
+- **Easy Integration** - Simple API for logging from anywhere in your Godot C# code
+
+## Installation
+1. Download or clone this repository
+2. Copy the `addons/RichLogger` folder to your Godot project's `addons` folder
+3. Compile project
+4. Enable the plugin in Godot via Project > Project Settings > Plugins
+
+Godot 4.7 Note:  There is currently a bug where manually-imported plugins always default to `.gdscript`.
+If you hit a compilation error when enabling the plugin, click the edit pencil and make sure the plugin is set to CSharp.
+
+## Usage
+### Basic Logging
+``` csharp
+Logger.Error("This is an error message");
+Logger.Warning("This is a warning message");
+Logger.Info("This is an information message");
+Logger.Debug("This is a debug message");
+Logger.Verbose("This is a verbose message");
+```
+
+### Formatted Logging
+``` csharp
+// Use BBCode for rich text formatting
+Logger.Info("[b]Bold text[/b] and [i]italic text[/i]");
+Logger.Debug("Player position: [color=yellow]" + player.Position + "[/color]");
+```
+
+### Stack Traces
+``` csharp
+// Enable stack traces from the toolbar or programmatically
+Logger.IncludeStackTraces = true;
+Logger.StackTraceDepth = 5;
+
+Logger.Error("Something went wrong");
+// Output includes stack trace with 5 frames
+```
+
+### Logging Objects
+``` csharp
+Logger.LogObject(LogLevel.Info, "Player", playerNode);
+// Output: Player: <Node:12345>
+```
+
+### File Logging
+Logs are automatically written to `user://logs/` when enabled:
+- Files are named: `logger_YYYY-MM-DD_HH-mm-ss_editor.log` or `logger_YYYY-MM-DD_HH-mm-ss_game.log`
+- Editor and game maintain separate log files
+- Automatically keeps last 10 log files (older files are deleted)
+- BBCode formatting is stripped for clean file output
+- Non-blocking I/O using Godot's WorkerThreadPool
+
+### Runtime Settings Changes
+All settings can be changed during gameplay:
+- Changes in editor toolbar automatically sync to running game
+- Settings persist across sessions via `user://logger_settings.cfg`
+- Updates check every 1 second with non-blocking file I/O
+
+## Contributing
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+## License
+This plugin is released under the MIT License. See the LICENSE file for details.  
+
+_Made with ❤️ for the Godot community_

--- a/addons/RichLogger/plugin.cfg
+++ b/addons/RichLogger/plugin.cfg
@@ -3,6 +3,6 @@
 name="RichLogger"
 description="Logger with colored logs and stack traces. Configurable from Editor Output window."
 author="Piotr Przestrzelski dimzi"
-version="1.0.0"
+version="1.0.2"
 language="C#"
 script="LoggerToolbarPlugin.cs"


### PR DESCRIPTION
- LICENSE + README copies inside addons/RichLogger (store guideline)
- bump plugin.cfg version to 1.0.2 (matches published stores)
- simplify .gitattributes to glob export-ignore; fixes unanchored LICENSE/README patterns stripping addon copies from archives
- one-click Release workflow: addon-only zip + tag + GitHub release
- Check Asset Store workflow: scrape store page version vs plugin.cfg
- Check Asset Library: compare version_string vs plugin.cfg instead of commit vs HEAD (no false alarms from test-only commits)
- reusable telegram-notify composite action, wired as on-failure notification into both checks and the test workflow